### PR TITLE
Mention xxd in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ amiibo™ parsing library
 
 Usage
 =====
-**libamiibo expects a binary dump. It will not work with XMLs or hexadecimal text files**. 
+**libamiibo expects a binary dump. It will not work with XMLs or hexadecimal text files**.  See the unix program `xxd` to convert from hexadecimal to binary.
 
 It offers support for encryption/decryption, figurine data, amiibo settings and AppData.
 


### PR DESCRIPTION
I thought it might be useful to point people who might have hex dumps at `xxd` since it can be used to convert to a binary dump pretty easily: 

``` bash
echo -n "8804943d25ea2631807d" | xxd -r -p | hexdump -C
```

or in practice: 

``` bash
cat normal.hex | xxd -r -p > normal.bin
```
