### PR TITLE
Fix typo: Shiek -> Sheik

### DIFF
--- a/libamiibo/Data/Figurine/AmiiboName.cs
+++ b/libamiibo/Data/Figurine/AmiiboName.cs
@@ -51,7 +51,7 @@ namespace LibAmiibo.Data.Figurine
             { 0x0014,   "Bowser" },
             { 0x0015,   "Bowser Jr." },
             { 0x0016,   "Toon Link" },
-            { 0x0017,   "Shiek" },
+            { 0x0017,   "Sheik" },
             { 0x0018,   "Ike" },
             { 0x0019,   "Dr. Mario" },
             { 0x001A,   "Wario" },

--- a/libamiibo/Data/Figurine/SubCharacter.cs
+++ b/libamiibo/Data/Figurine/SubCharacter.cs
@@ -35,7 +35,7 @@ namespace LibAmiibo.Data.Figurine
             { 0x0008ff, "Turbo Charge" },
             { 0x008001, "Yarn" },
             { 0x010001, "Toon" },
-            { 0x010101, "Shiek" },
+            { 0x010101, "Sheik" },
             { 0x010201, "-dorf" },
             { 0x018101, "Winter" },
             { 0x018102, "Festival" },


### PR DESCRIPTION
Fixed a typo for amiibo character Sheik
https://zelda.gamepedia.com/Sheik